### PR TITLE
Address rm: cannot remove ‘*.xml’ and ‘*.gz’: No such file or directory.

### DIFF
--- a/download_xml.sh
+++ b/download_xml.sh
@@ -2,7 +2,7 @@
 
 mkdir -p dbs
 cd dbs
-rm *.xml
+rm -f *.xml
 
 year=`date +"%Y"`
 for i in $(seq -f "%04g" 2002 $year)
@@ -11,4 +11,4 @@ do
     gunzip nvdcve-$i.xml.gz
 done
 
-rm *.gz
+rm -f *.gz


### PR DESCRIPTION
Upon the first execution, there is no .xml to remove. After the loop finishes, all downloaded `.xml.gz` files should have been already gunzipped.

Using `rm -f` avoids the "No such file or directory" noise.